### PR TITLE
Handle zero-length files

### DIFF
--- a/concat.go
+++ b/concat.go
@@ -146,7 +146,7 @@ func (r *RecursiveConcat) mergePair(ctx context.Context, objectList []*S3Obj, tr
 			// Debugf(ctx,"uploadPart key:%d", len(o.Data))
 			part, err = r.uploadPart(o, uploadId, bucket, key, int32(i+1))
 			accumSize += int64(len(o.Data))
-		} else {
+		} else if o.Size > 0 {
 			// Debugf(ctx,"uploadPartCopy bucket:%s key:%s %d", o.Bucket, *o.Key, len(o.Data))
 			part, err = r.uploadPartCopy(o, uploadId, bucket, key, int32(i+1), trim, o.Size)
 			accumSize += (int64(o.Size) - trim)
@@ -156,7 +156,9 @@ func (r *RecursiveConcat) mergePair(ctx context.Context, objectList []*S3Obj, tr
 			// fmt.Print(err.Error())
 			return complete, err
 		}
-		parts = append(parts, part)
+		if o.Size > 0 {
+			parts = append(parts, part)
+		}
 	}
 
 	completeOutput, err := r.Client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{


### PR DESCRIPTION
*Description of changes:*

`s3tar` fails when creating an archive including a zero-length object.

For example, if `s3://metadaddy-private/images` contains a zero-length object:

```
% s3tar --region us-west-1 --create -f s3://metadaddy-private/images.tar s3://metadaddy-private/images
panic: operation error S3: UploadPartCopy, https response error StatusCode: 400, RequestID: 7QANEX33NK9KH0MN, HostID: 5SK7CHMdTcdlf/PjPjLufrMXpMHLDODhqKH7Q7/4liApUO1USmtEx9FDsIEbOBc1zeFgI3SGnP635hJrIS2/Sw==, api error InvalidArgument: The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy
```

This is because in `uploadPartCopy`, if the object size is zero, `copySourceRange` is set to `bytes=0--1`, which is invalid.

We fix this in `mergePair` by simply skipping the part if it has zero size.

The corresponding change when extracting an archive is in `extractRange` - when the size is zero, we create a zero-length part with `UploadPart`, rather than copying a range of bytes with `UploadPartCopy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.