### PR TITLE
Add support for custom endpoint via --endpointUrl parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,11 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# s3tar Binaries
+bin/
+
+# IntelliJ
+.idea/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/s3tar.go
+++ b/s3tar.go
@@ -85,10 +85,11 @@ func ServerSideTar(incoming context.Context, svc *s3.Client, opts *S3TarS3Option
 	if smallFiles {
 		var err error
 		rc, err = NewRecursiveConcat(ctx, RecursiveConcatOptions{
-			Bucket:    opts.DstBucket,
-			DstPrefix: opts.DstPrefix,
-			DstKey:    opts.DstKey,
-			Region:    opts.Region,
+			Bucket:      opts.DstBucket,
+			DstPrefix:   opts.DstPrefix,
+			DstKey:      opts.DstKey,
+			Region:      opts.Region,
+			EndpointUrl: opts.EndpointUrl,
 		})
 		if err != nil {
 			log.Fatal(err.Error())
@@ -131,10 +132,11 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 
 	ctx = context.WithValue(ctx, contextKeyS3Client, svc)
 	concater, err := NewRecursiveConcat(ctx, RecursiveConcatOptions{
-		Bucket:    opts.DstBucket,
-		DstPrefix: opts.DstPrefix,
-		DstKey:    opts.DstKey,
-		Region:    opts.Region,
+		Bucket:      opts.DstBucket,
+		DstPrefix:   opts.DstPrefix,
+		DstKey:      opts.DstKey,
+		Region:      opts.Region,
+		EndpointUrl: opts.EndpointUrl,
 	})
 	if err != nil {
 		log.Fatal(err.Error())

--- a/utils.go
+++ b/utils.go
@@ -44,6 +44,7 @@ type S3TarS3Options struct {
 	DeleteSource       bool
 	SmallFiles         bool
 	Region             string
+	EndpointUrl        string
 	TarFormat          string
 }
 


### PR DESCRIPTION
*Description of changes:*

Add `--endpointUrl` parameter to specify custom S3 endpoint URL.

Example usage with [Backblaze B2](https://www.backblaze.com/b2/cloud-storage.html):

```
% aws s3 ls --endpoint-url https://s3.us-west-004.backblazeb2.com s3://metadaddy-private/images/
2023-03-21 09:48:31       8882 AskPat_tn.jpg
2023-03-21 09:48:29     764533 Logo Slide.png
2023-03-21 09:48:30       2597 Logo Slide_tn.jpg
2023-03-21 09:51:42   14942282 reston-dc.png

% bin/s3tar-darwin-arm64 --region us-west-004 --endpoint s3.us-west-004.backblazeb2.com --create -v -f s3://metadaddy-private/images.tar s3://metadaddy-private/images/
processing 4 Amazon S3 Objects
final size 0GB (without tar headers + padding)
estimated final size: 15728830 bytes (with headers + padding)
multipart part-size: 5242880 bytes
deleting all intermediate objects
Final Object: s3://metadaddy-private/images.tar
Time elapsed: 13.764813042s

% aws s3 ls --endpoint-url https://s3.us-west-004.backblazeb2.com s3://metadaddy-private/images.tar
2023-03-21 13:12:41   15729152 images.tar

% bin/s3tar-darwin-arm64 --region us-west-004 --endpointUrl https://s3.us-west-004.backblazeb2.com --list -f s3://metadaddy-private/images.tar                                     
images/AskPat_tn.jpg
images/Logo Slide.png
images/Logo Slide_tn.jpg
images/reston-dc.png

% bin/s3tar-darwin-arm64 --region us-west-004 --endpointUrl https://s3.us-west-004.backblazeb2.com --extract -f s3://metadaddy-private/images.tar --location s3://metadaddy-private/extracted/

% aws s3 ls --recursive --endpoint-url https://s3.us-west-004.backblazeb2.com s3://metadaddy-private/extracted/
2023-03-21 13:13:36       8882 extracted/images/AskPat_tn.jpg
2023-03-21 13:13:36     764533 extracted/images/Logo Slide.png
2023-03-21 13:13:36       2597 extracted/images/Logo Slide_tn.jpg
2023-03-21 13:13:36   14942282 extracted/images/reston-dc.png

% aws s3 cp --endpoint-url https://s3.us-west-004.backblazeb2.com s3://metadaddy-private/images.tar images.tar
download: s3://metadaddy-private/images.tar to ./images.tar        

% tar tvf images.tar 
-rw-------  0 0      0         296 Mar 21 13:12 toc.csv
-rw-------  0 0      0        8882 Mar 21 09:48 images/AskPat_tn.jpg
-rw-------  0 0      0      764533 Mar 21 09:48 images/Logo Slide.png
-rw-------  0 0      0        2597 Mar 21 09:48 images/Logo Slide_tn.jpg
-rw-------  0 0      0    14942282 Mar 21 09:51 images/reston-dc.png

% tar xvf images.tar
x toc.csv
x images/AskPat_tn.jpg
x images/Logo Slide.png
x images/Logo Slide_tn.jpg
x images/reston-dc.png

% cat toc.csv 
images/AskPat_tn.jpg,3584,8882,"""cdbddb75a8372d3e0903be34cbee165b"""
images/Logo Slide.png,14336,764533,"""52659e3e4ca1efdf6110246f8d09fa4e"""
images/Logo Slide_tn.jpg,780800,2597,"""c6bdd336555c2c171cbedc2d8211977d"""
images/reston-dc.png,785408,14942282,"""0c124a6d990f24ac0f578ac31b7a170a"""

% ls -l images     
total 30720
-rw-------  1 ppatterson  staff      8882 Mar 21 09:48 AskPat_tn.jpg
-rw-------  1 ppatterson  staff    764533 Mar 21 09:48 Logo Slide.png
-rw-------  1 ppatterson  staff      2597 Mar 21 09:48 Logo Slide_tn.jpg
-rw-------  1 ppatterson  staff  14942282 Mar 21 09:51 reston-dc.png
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
