### PR TITLE
set a custom user-agent

### DIFF
--- a/s3tar.go
+++ b/s3tar.go
@@ -101,6 +101,7 @@ func createFromList(ctx context.Context, svc *s3.Client, objectList []*S3Obj, op
 		Debugf(ctx, "Processing small files")
 		var err error
 		rc, err = NewRecursiveConcat(ctx, RecursiveConcatOptions{
+			Client:      svc,
 			Bucket:      opts.DstBucket,
 			DstPrefix:   opts.DstPrefix,
 			DstKey:      opts.DstKey,
@@ -164,6 +165,7 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 
 	ctx = context.WithValue(ctx, contextKeyS3Client, svc)
 	concater, err := NewRecursiveConcat(ctx, RecursiveConcatOptions{
+		Client:      svc,
 		Bucket:      opts.DstBucket,
 		DstPrefix:   opts.DstPrefix,
 		DstKey:      opts.DstKey,


### PR DESCRIPTION
Added a custom user-agent. Useful for debugging when customers enable Amazon S3 Server Access logs.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
