### PR TITLE
Preserve POSIX metadata

### DIFF
--- a/cmd/s3tar/main.go
+++ b/cmd/s3tar/main.go
@@ -388,11 +388,12 @@ func run(args []string) error {
 					fmt.Printf("appending '/' to destination path\n")
 				}
 				s3opts := &s3tar.S3TarS3Options{
-					Threads:      threads,
-					DeleteSource: false,
-					Region:       region,
-					EndpointUrl:  endpointUrl,
-					ExternalToc:  externalToc,
+					Threads:               threads,
+					DeleteSource:          false,
+					Region:                region,
+					EndpointUrl:           endpointUrl,
+					ExternalToc:           externalToc,
+					PreservePOSIXMetadata: preservePosixMetadata,
 				}
 				s3opts.SrcBucket, s3opts.SrcKey = s3tar.ExtractBucketAndPath(archiveFile)
 				s3opts.SrcPrefix = filepath.Dir(s3opts.SrcKey)

--- a/cmd/s3tar/main.go
+++ b/cmd/s3tar/main.go
@@ -8,6 +8,11 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
@@ -16,10 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	s3tar "github.com/awslabs/amazon-s3-tar-tool"
 	"github.com/urfave/cli/v2"
-	"log"
-	"os"
-	"path/filepath"
-	"strconv"
 )
 
 var (
@@ -69,6 +70,7 @@ func run(args []string) error {
 	var tagSetInput string
 	var kmsKeyID string
 	var sseAlgo string
+	var preservePosixMetadata bool
 
 	var tagSet types.Tagging
 	var err error
@@ -250,6 +252,11 @@ func run(args []string) error {
 				Usage:       "aws:kms or AES256",
 				Destination: &sseAlgo,
 			},
+			&cli.BoolFlag{
+				Name:        "preserve-posix-metadata",
+				Usage:       "Preserve POSIX permisions, uid and gid if present in S3 object metadata. See https://docs.aws.amazon.com/fsx/latest/LustreGuide/posix-metadata-support.html",
+				Destination: &preservePosixMetadata,
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			logLevel := parseLogLevel(cCtx.Count("verbose"))
@@ -307,16 +314,17 @@ func run(args []string) error {
 				}
 
 				s3opts := &s3tar.S3TarS3Options{
-					SrcManifest:        manifestPath,
-					SkipManifestHeader: skipManifestHeader,
-					Threads:            threads,
-					DeleteSource:       false,
-					Region:             region,
-					EndpointUrl:        endpointUrl,
-					ConcatInMemory:     concatInMemory,
-					UrlDecode:          urlDecode,
-					UserMaxPartSize:    userPartMaxSize,
-					ObjectTags:         tagSet,
+					SrcManifest:           manifestPath,
+					SkipManifestHeader:    skipManifestHeader,
+					Threads:               threads,
+					DeleteSource:          false,
+					Region:                region,
+					EndpointUrl:           endpointUrl,
+					ConcatInMemory:        concatInMemory,
+					UrlDecode:             urlDecode,
+					UserMaxPartSize:       userPartMaxSize,
+					ObjectTags:            tagSet,
+					PreservePOSIXMetadata: preservePosixMetadata,
 				}
 				s3opts.DstBucket, s3opts.DstKey = s3tar.ExtractBucketAndPath(archiveFile)
 				s3opts.DstPrefix = filepath.Dir(s3opts.DstKey)

--- a/concat.go
+++ b/concat.go
@@ -39,7 +39,7 @@ type RecursiveConcatOptions struct {
 
 func (r *RecursiveConcat) CreateFirstBlock(ctx context.Context) {
 	//randomize?
-	key := filepath.Join(r.DstPrefix, r.DstKey, "parts", "min-size-block")
+	key := filepath.Join(r.DstPrefix, r.DstKey+".parts", "min-size-block")
 	now := time.Now()
 	output, err := putObject(ctx, r.Client, r.Bucket, key, pad)
 	if err != nil {

--- a/extract.go
+++ b/extract.go
@@ -10,11 +10,13 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -87,11 +89,42 @@ func List(ctx context.Context, svc *s3.Client, bucket, key string, opts *S3TarS3
 }
 
 func extractRange(ctx context.Context, svc *s3.Client, bucket, key, dstBucket, dstKey string, start, size int64, opts *S3TarS3Options) error {
+	var Metadata map[string]string
+	if opts.PreservePOSIXMetadata {
+		hdr, headerSize, err := extractTarHeaderEnding(ctx, svc, bucket, key, start)
+		if err != nil {
+			Warnf(ctx, "unable to extract tar header for %s, cannot set permissions", dstKey)
+			hdr = nil
+		}
+		if hdr != nil {
+			var mtime string = strconv.FormatInt(hdr.ModTime.UnixMilli(), 10)
+			var hasATime = hdr.Format == tar.FormatGNU || hdr.Format == tar.FormatPAX
+			var atime string
+			if hasATime {
+				atime = strconv.FormatInt(hdr.AccessTime.UnixMilli(), 10)
+			} else {
+				atime = mtime
+			}
+			Metadata = map[string]string{
+				"file-permissions": fmt.Sprintf("%#o", hdr.Mode),
+				"file-owner":       strconv.Itoa(hdr.Uid),
+				"file-group":       strconv.Itoa(hdr.Gid),
+				"file-atime":       atime,
+				"file-mtime":       mtime,
+			}
+			Debugf(ctx, "got posix metadata permissions: %s uid: %s gid: %s name: %s from header size %d, ending %d, format %s",
+				Metadata["file-permissions"], Metadata["file-owner"], Metadata["file-group"], hdr.Name,
+				headerSize, start, hdr.Format,
+			)
+		}
+
+	}
 
 	output, err := svc.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
-		Bucket: aws.String(dstBucket),
-		Key:    aws.String(dstKey),
-		ACL:    types.ObjectCannedACLBucketOwnerFullControl,
+		Bucket:   aws.String(dstBucket),
+		Key:      aws.String(dstKey),
+		ACL:      types.ObjectCannedACLBucketOwnerFullControl,
+		Metadata: Metadata,
 	})
 	if err != nil {
 		return err
@@ -195,6 +228,30 @@ retry:
 	ctr += 1
 
 	output, err := getObjectRange(ctx, svc, bucket, key, 0, headerSize-1)
+	if err != nil {
+		return nil, 0, err
+	}
+	tr := tar.NewReader(output)
+	hdr, err := tr.Next()
+	if err != nil {
+		headerSize = paxTarHeaderSize
+		goto retry
+	}
+	return hdr, headerSize, err
+}
+func extractTarHeaderEnding(ctx context.Context, svc *s3.Client, bucket, key string, end int64) (*tar.Header, int64, error) {
+
+	headerSize := gnuTarHeaderSize
+	ctr := 0
+
+retry:
+
+	if ctr >= 2 {
+		Fatalf(ctx, "unable to parse header ending %d from TAR", end)
+	}
+	ctr += 1
+
+	output, err := getObjectRange(ctx, svc, bucket, key, end-headerSize, end-1)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/extract.go
+++ b/extract.go
@@ -100,10 +100,13 @@ func extractRange(ctx context.Context, svc *s3.Client, bucket, key, dstBucket, d
 			var mtime string = strconv.FormatInt(hdr.ModTime.UnixMilli(), 10)
 			var hasATime = hdr.Format == tar.FormatGNU || hdr.Format == tar.FormatPAX
 			var atime string
+			var ctime string
 			if hasATime {
 				atime = strconv.FormatInt(hdr.AccessTime.UnixMilli(), 10)
+				ctime = strconv.FormatInt(hdr.ChangeTime.UnixMilli(), 10)
 			} else {
 				atime = mtime
+				ctime = mtime
 			}
 			Metadata = map[string]string{
 				"file-permissions": fmt.Sprintf("%#o", hdr.Mode),
@@ -111,6 +114,7 @@ func extractRange(ctx context.Context, svc *s3.Client, bucket, key, dstBucket, d
 				"file-group":       strconv.Itoa(hdr.Gid),
 				"file-atime":       atime,
 				"file-mtime":       mtime,
+				"file-ctime":       ctime,
 			}
 			Debugf(ctx, "got posix metadata permissions: %s uid: %s gid: %s name: %s from header size %d, ending %d, format %s",
 				Metadata["file-permissions"], Metadata["file-owner"], Metadata["file-group"], hdr.Name,

--- a/headers.go
+++ b/headers.go
@@ -12,14 +12,47 @@ import (
 	"log"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-func buildHeader(o, prev *S3Obj, addZeros bool) S3Obj {
+// buildHeader builds a tar header for the given S3 object.
+//
+// Parameters:
+//   - o: The S3 object for which the tar header needs to be built.
+//   - prev: The previous S3 object.
+//   - addZeros: A flag indicating whether to add zeros.
+//   - head: The head object containing S3 metadata, used to set file permissions, owner, and group.
+//
+// Returns:
+//   - S3Obj: The S3 object with the built tar header.
+//
+// Example:
+//
+//	o := &S3Obj{
+//	  Key:           aws.String("example.txt"),
+//	  Size:          aws.Int64(1024),
+//	  LastModified:  aws.Time(time.Now()),
+//	}
+//	prev := &S3Obj{
+//	  Size: aws.Int64(512),
+//	}
+//	addZeros := true
+//	head := &s3.HeadObjectOutput{
+//	  Metadata: map[string]*string{
+//	    "file-permissions": aws.String("0644"),
+//	    "file-owner":       aws.String("1000"),
+//	    "file-group":       aws.String("1000"),
+//	  },
+//	}
+//	result := buildHeader(o, prev, addZeros, head)
+//	fmt.Println(result)
+func buildHeader(o, prev *S3Obj, addZeros bool, head *s3.HeadObjectOutput) S3Obj {
 
 	name := *o.Key
 	var buff bytes.Buffer
@@ -33,6 +66,8 @@ func buildHeader(o, prev *S3Obj, addZeros bool) S3Obj {
 		AccessTime: time.Now(),
 		Format:     tarFormat,
 	}
+	setHeaderPermissions(hdr, head)
+
 	if addZeros {
 		buff.Write(pad)
 	}
@@ -62,6 +97,39 @@ func buildHeader(o, prev *S3Obj, addZeros bool) S3Obj {
 	}
 }
 
+// setHeaderPermissions sets the permissions, owner, and group of a tar.Header based on the metadata provided in the s3.HeadObjectOutput.
+// If the "file-permissions" metadata is present, it is parsed as an octal string and set as the Mode of the tar.Header.
+// If the "file-owner" metadata is present, it is parsed as an integer and set as the Uid of the tar.Header.
+// If the "file-group" metadata is present, it is parsed as an integer and set as the Gid of the tar.Header.
+// The hdr parameter is a pointer to the tar.Header that will be modified.
+// The head parameter is a pointer to the s3.HeadObjectOutput that contains the metadata.
+// If head is nil or if the metadata is empty, no modifications will be made to the tar.Header.
+func setHeaderPermissions(hdr *tar.Header, head *s3.HeadObjectOutput) {
+	if head != nil && len(head.Metadata) > 0 {
+		if modeStr, ok := head.Metadata["file-permissions"]; ok {
+			modeInt, err := strconv.ParseInt(modeStr, 8, 64)
+			if err != nil {
+				log.Fatal(err)
+			}
+			hdr.Mode = modeInt
+		}
+		if ownerStr, ok := head.Metadata["file-owner"]; ok {
+			ownerInt, err := strconv.ParseInt(ownerStr, 10, 32)
+			if err != nil {
+				log.Fatal(err)
+			}
+			hdr.Uid = int(ownerInt)
+		}
+		if groupStr, ok := head.Metadata["file-group"]; ok {
+			groupInt, err := strconv.ParseInt(groupStr, 10, 32)
+			if err != nil {
+				log.Fatal(err)
+			}
+			hdr.Gid = int(groupInt)
+		}
+	}
+}
+
 func buildHeaders(objectList []*S3Obj, frontPad bool) []*S3Obj {
 	headers := []*S3Obj{}
 	for i := 0; i < len(objectList); i++ {
@@ -77,7 +145,11 @@ func buildHeaders(objectList []*S3Obj, frontPad bool) []*S3Obj {
 		if !frontPad {
 			addZero = false
 		}
-		newObject := buildHeader(o, prev, addZero)
+		/* buildHeaders is only called from processHeaders which builds the manifest using createCSVTOC.
+		 * inspection of createCSVTOC shows that file permissions, uid and gid are not used in the manifest
+		 * therefore we do not need to pass in the head object output
+		 */
+		newObject := buildHeader(o, prev, addZero, nil)
 		newObject.PartNum = i
 		newObject.Key = aws.String(filename + ".hdr")
 		headers = append(headers, &newObject)

--- a/headers.go
+++ b/headers.go
@@ -140,6 +140,9 @@ func setHeaderPermissions(hdr *tar.Header, s3metadata map[string]string) {
 		if mtimeStr, ok := s3metadata["file-mtime"]; ok {
 			var timeVal = s3metadataToTime(mtimeStr)
 			hdr.ModTime = timeVal
+		}
+		if ctimeStr, ok := s3metadata["file-ctime"]; ok {
+			var timeVal = s3metadataToTime(ctimeStr)
 			hdr.ChangeTime = timeVal
 		}
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
@@ -31,7 +32,8 @@ func buildToc(ctx context.Context, objectList []*S3Obj) (*S3Obj, *S3Obj, error) 
 	tocObj := NewS3Obj()
 	tocObj.Key = aws.String("toc.csv")
 	tocObj.AddData(toc.Bytes())
-	tocHeader := buildHeader(tocObj, nil, false)
+	// passing nil as we don't need to set permissions/owner/group for toc.csv
+	tocHeader := buildHeader(tocObj, nil, false, nil)
 	tocHeader.Bucket = objectList[0].Bucket
 	tocObj.Bucket = objectList[0].Bucket
 

--- a/mem_concat.go
+++ b/mem_concat.go
@@ -26,7 +26,7 @@ func buildInMemoryConcat(ctx context.Context, client *s3.Client, objectList []*S
 	}
 
 	if estimatedSize < fileSizeMin {
-		data, err := tarGroup(ctx, client, objectList, opts.PreservePOSIXMetadata)
+		data, err := tarGroup(ctx, client, objectList, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func buildInMemoryConcat(ctx context.Context, client *s3.Client, objectList []*S
 				g.Go(func() error {
 
 					Infof(ctx, "Part %d of %d has %d objects\n", i+1, len(groups), len(group))
-					data, err := tarGroup(ctx, client, group, opts.PreservePOSIXMetadata)
+					data, err := tarGroup(ctx, client, group, opts)
 					if err != nil {
 						return err
 					}
@@ -215,8 +215,7 @@ func uploadPart(ctx context.Context, client *s3.Client, uploadId, bucket, key st
 
 }
 
-func tarGroup(ctx context.Context, client *s3.Client, objectList []*S3Obj, preservePOSIXMetadata bool) ([]byte, error) {
-
+func tarGroup(ctx context.Context, client *s3.Client, objectList []*S3Obj, opts *S3TarS3Options) ([]byte, error) {
 	buf := bytes.Buffer{}
 	tw := tar.NewWriter(&buf)
 
@@ -243,7 +242,7 @@ func tarGroup(ctx context.Context, client *s3.Client, objectList []*S3Obj, prese
 			AccessTime: *o.LastModified,
 			Format:     tarFormat,
 		}
-		if preservePOSIXMetadata {
+		if opts.PreservePOSIXMetadata {
 			setHeaderPermissions(&h, s3metadata)
 		}
 

--- a/s3tar.go
+++ b/s3tar.go
@@ -170,7 +170,7 @@ func createFromList(ctx context.Context, svc *s3.Client, objectList []*S3Obj, op
 func cleanUp(ctx context.Context, svc *s3.Client, opts *S3TarS3Options) {
 	Infof(ctx, "deleting all intermediate objects")
 	scratchDirs := []string{
-		filepath.Join(opts.DstPrefix, opts.DstKey, "parts"),
+		filepath.Join(opts.DstPrefix, opts.DstKey+".parts"),
 		filepath.Join(opts.DstPrefix, opts.DstKey, "headers"),
 	}
 	for _, path := range scratchDirs {
@@ -240,7 +240,7 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 		}
 
 		name := fmt.Sprintf("%d.part-%d.hdr", i, nextIndex)
-		key := filepath.Join(opts.DstPrefix, opts.DstKey, "parts", name)
+		key := filepath.Join(opts.DstPrefix, opts.DstKey+".parts", name)
 		wg.Add()
 		go func(nextObject *S3Obj, obj *S3Obj, key string, partNum int) {
 			var p1 = obj
@@ -350,7 +350,7 @@ func breakUpList(ctx context.Context, svc *s3.Client, objectList []*S3Obj, opts 
 				if err != nil {
 					return err
 				}
-				tempKey := filepath.Join(opts.DstPrefix, opts.DstKey, "parts", fn)
+				tempKey := filepath.Join(opts.DstPrefix, opts.DstKey+".parts", fn)
 				obj, err := concatObjects(ctx, svc, 0, batch, opts.DstBucket, tempKey)
 				if err == nil {
 					obj.PartNum = i + 1
@@ -385,7 +385,7 @@ func processLargeFiles(ctx context.Context, svc *s3.Client, objectList []*S3Obj,
 	}
 	Debugf(ctx, "list reduced\n")
 
-	tempKey := filepath.Join(opts.DstPrefix, opts.DstKey, "parts", "output.temp")
+	tempKey := filepath.Join(opts.DstPrefix, opts.DstKey+".parts", "output.temp")
 	concatObj, err := concatObjects(ctx, svc, 0, results, opts.DstBucket, tempKey)
 	if err != nil {
 		return nil, err
@@ -636,7 +636,7 @@ func processSmallFiles(ctx context.Context, client *s3.Client, objectList []*S3O
 //   - *S3Obj: The final concatenated part.
 //   - error: Any error encountered during the process.
 func _processSmallFiles(ctx context.Context, objectList []*S3Obj, headList []*s3.HeadObjectOutput, start, end int, opts *S3TarS3Options) (*S3Obj, error) {
-	parentPartsKey := filepath.Join(opts.DstPrefix, opts.DstKey, "parts")
+	parentPartsKey := filepath.Join(opts.DstPrefix, opts.DstKey+".parts")
 	parts := []*S3Obj{}
 	for i, partNum := start, 0; i <= end; i, partNum = i+1, partNum+1 {
 		Debugf(ctx, "Processing: %s", *objectList[i].Key)

--- a/s3tar.go
+++ b/s3tar.go
@@ -9,7 +9,6 @@ import (
 	"container/list"
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"log"
 	"path/filepath"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -122,6 +123,24 @@ func createFromList(ctx context.Context, svc *s3.Client, objectList []*S3Obj, op
 		if err != nil {
 			return err
 		}
+		headList := make([]*s3.HeadObjectOutput, len(objectList))
+		if opts.PreservePOSIXMetadata {
+			var wg sync.WaitGroup
+			for i, obj := range objectList {
+				wg.Add(1)
+				go func(i int, obj *S3Obj) {
+					defer wg.Done()
+					if obj.NoHeaderRequired {
+						headList[i] = nil
+					} else {
+						head := fetchS3ObjectHead(ctx, svc, obj)
+						headList[i] = head
+					}
+				}(i, obj)
+			}
+			wg.Wait()
+		}
+
 		Debugf(ctx, "building toc")
 		manifestObj, _, err := buildToc(ctx, objectList)
 		if err != nil {
@@ -129,8 +148,9 @@ func createFromList(ctx context.Context, svc *s3.Client, objectList []*S3Obj, op
 			return err
 		}
 		objectList = append([]*S3Obj{manifestObj}, objectList...)
+		headList = append([]*s3.HeadObjectOutput{nil}, headList...)
 		Debugf(ctx, "prepended toc: %s Size: %d len.Data: %d", *manifestObj.Key, *manifestObj.Size, len(manifestObj.Data))
-		concatObj, err = processSmallFiles(ctx, svc, objectList, opts.DstKey, opts)
+		concatObj, err = processSmallFiles(ctx, svc, objectList, headList, opts.DstKey, opts)
 		if err != nil {
 			return err
 		}
@@ -210,22 +230,38 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 	resultsChan := make(chan concatresult)
 	var bytesAccum int64
 	for i, obj := range objectList {
-		var p1 = obj
-		var p2 *S3Obj = nil
-		next := i + 1
-		if next < len(objectList) {
-			h := buildHeader(objectList[next], p1, false)
-			p2 = &h
-			bytesAccum += *p1.Size + *p2.Size
+		nextIndex := i + 1
+		var notLastBlock = nextIndex < len(objectList)
+		var nextObject *S3Obj
+		if notLastBlock {
+			nextObject = objectList[nextIndex]
 		} else {
-			eofPadding := generateLastBlock(bytesAccum+*obj.Size, opts)
-			p2 = eofPadding
+			nextObject = nil
 		}
-		pairs := []*S3Obj{p1, p2}
-		name := fmt.Sprintf("%d.part-%d.hdr", i, next)
+
+		name := fmt.Sprintf("%d.part-%d.hdr", i, nextIndex)
 		key := filepath.Join(opts.DstPrefix, opts.DstKey, "parts", name)
 		wg.Add()
-		go func(pairs []*S3Obj, key string, partNum int) {
+		go func(nextObject *S3Obj, obj *S3Obj, key string, partNum int) {
+			var p1 = obj
+			var p2 *S3Obj = nil
+			if notLastBlock {
+				var head *s3.HeadObjectOutput
+				if opts.PreservePOSIXMetadata {
+					head = fetchS3ObjectHead(ctx, svc, nextObject)
+				} else {
+					head = nil
+				}
+
+				h := buildHeader(nextObject, p1, false, head)
+				p2 = &h
+				bytesAccum += *p1.Size + *p2.Size
+			} else {
+				eofPadding := generateLastBlock(bytesAccum+*obj.Size, opts)
+				p2 = eofPadding
+			}
+			var pairs = []*S3Obj{p1, p2}
+
 			res, err := concater.ConcatObjects(ctx, pairs, opts.DstBucket, key)
 			if err != nil {
 				Infof(ctx, err.Error())
@@ -233,7 +269,7 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 			res.PartNum = partNum
 			resultsChan <- concatresult{res, err}
 			wg.Done()
-		}(pairs, key, i+1)
+		}(nextObject, obj, key, i+1)
 
 	}
 	go func() {
@@ -250,6 +286,18 @@ func concatObjAndHeader(ctx context.Context, svc *s3.Client, objectList []*S3Obj
 	}
 	sort.Sort(byPartNum(results))
 	return results, nil
+}
+
+func fetchS3ObjectHead(ctx context.Context, svc *s3.Client, nextObject *S3Obj) *s3.HeadObjectOutput {
+	Debugf(ctx, "fetching head for %s/%s", *&nextObject.Bucket, *nextObject.Key)
+	head, err := svc.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(nextObject.Bucket),
+		Key:    nextObject.Key,
+	})
+	if err != nil {
+		Fatalf(ctx, err.Error())
+	}
+	return head
 }
 
 type batchGroup struct {
@@ -476,13 +524,14 @@ func redistribute(ctx context.Context, client *s3.Client, obj *S3Obj, trimoffset
 
 }
 
-func processSmallFiles(ctx context.Context, client *s3.Client, objectList []*S3Obj, dstKey string, opts *S3TarS3Options) (*S3Obj, error) {
+func processSmallFiles(ctx context.Context, client *s3.Client, objectList []*S3Obj, headList []*s3.HeadObjectOutput, dstKey string, opts *S3TarS3Options) (*S3Obj, error) {
 
 	Debugf(ctx, "processSmallFiles path")
 
 	indexList, totalSize := createGroups(ctx, objectList)
 	eofPadding := generateLastBlock(totalSize, opts)
 	objectList = append(objectList, eofPadding)
+	headList = append(headList, nil)
 	indexList[len(indexList)-1].End = len(objectList) - 1
 
 	g := new(errgroup.Group)
@@ -496,7 +545,7 @@ func processSmallFiles(ctx context.Context, client *s3.Client, objectList []*S3O
 		end := p.End
 		Debugf(ctx, "Part %06d range: %d - %d", i+1, p.Start, p.End)
 		g.Go(func() error {
-			newPart, err := _processSmallFiles(ctx, objectList, start, end, opts)
+			newPart, err := _processSmallFiles(ctx, objectList, headList, start, end, opts)
 			if err != nil {
 				return err
 			}
@@ -565,7 +614,28 @@ func processSmallFiles(ctx context.Context, client *s3.Client, objectList []*S3O
 
 }
 
-func _processSmallFiles(ctx context.Context, objectList []*S3Obj, start, end int, opts *S3TarS3Options) (*S3Obj, error) {
+// _processSmallFiles processes a range of small files from the given objectList and headList.
+// It generates tar headers for each file and concatenates them into a finalPart.
+// If a file does not require a tar header, it is appended directly to the parts list.
+// The headList is either the results of S3 HEAD requests or nil.
+//
+//	if present, the head is used to set POSIX file permissions, owner and group.
+//
+// The generated parts are then concatenated using the rc.ConcatObjects function.
+// The resulting finalPart is returned along with any error encountered during the process.
+//
+// Parameters:
+//   - ctx: The context.Context for the operation.
+//   - objectList: A slice of S3Obj representing the list of objects to process.
+//   - headList: A slice of s3.HeadObjectOutput or nil, used to set permissions, uid and gid
+//   - start: The starting index of the range of files to process.
+//   - end: The ending index of the range of files to process.
+//   - opts: A pointer to S3TarS3Options containing the options for S3 operations.
+//
+// Returns:
+//   - *S3Obj: The final concatenated part.
+//   - error: Any error encountered during the process.
+func _processSmallFiles(ctx context.Context, objectList []*S3Obj, headList []*s3.HeadObjectOutput, start, end int, opts *S3TarS3Options) (*S3Obj, error) {
 	parentPartsKey := filepath.Join(opts.DstPrefix, opts.DstKey, "parts")
 	parts := []*S3Obj{}
 	for i, partNum := start, 0; i <= end; i, partNum = i+1, partNum+1 {
@@ -578,7 +648,7 @@ func _processSmallFiles(ctx context.Context, objectList []*S3Obj, start, end int
 			if (i - 1) >= 0 {
 				prev = objectList[i-1]
 			}
-			header := buildHeader(objectList[i], prev, false)
+			header := buildHeader(objectList[i], prev, false, headList[i])
 			header.Bucket = opts.DstBucket
 			pairs := []*S3Obj{&header, {
 				Object:  objectList[i].Object, // fix this
@@ -655,7 +725,8 @@ func createGroups(ctx context.Context, objectList []*S3Obj) ([]Index, int64) {
 	partSize := findMinimumPartSize(estimatedSize, 0)
 	Infof(ctx, "estimated final size: %d bytes (with headers + padding)\nmultipart part-size: %d bytes\n", estimatedSize, partSize)
 
-	h := buildHeader(objectList[0], nil, false)
+	// passing nil for head, header is only used to estimate size, so permissions are not needed
+	h := buildHeader(objectList[0], nil, false, nil)
 	currSize := *h.Size + *objectList[0].Size
 	var totalSize int64 = currSize
 	for i := 1; i < len(objectList); i++ {
@@ -663,7 +734,8 @@ func createGroups(ctx context.Context, objectList []*S3Obj) ([]Index, int64) {
 		if (i - 1) >= 0 {
 			prev = objectList[i-1]
 		}
-		header := buildHeader(objectList[i], prev, false)
+		// passing nil for head, header is only used to estimate size, so permissions are not needed
+		header := buildHeader(objectList[i], prev, false, nil)
 		l := int64(len(header.Data)) + *objectList[i].Size
 		currSize += l
 		totalSize += l

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"log"
 	"net/url"
@@ -20,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -37,28 +38,29 @@ var (
 
 // S3TarS3Options options to create an archive
 type S3TarS3Options struct {
-	SrcManifest        string
-	SkipManifestHeader bool
-	SrcBucket          string
-	SrcPrefix          string
-	SrcKey             string
-	DstBucket          string
-	DstPrefix          string
-	DstKey             string
-	Threads            int
-	DeleteSource       bool
-	Region             string
-	EndpointUrl        string
-	ExternalToc        string
-	tarFormat          tar.Format
-	storageClass       types.StorageClass
-	extractPrefix      string
-	ConcatInMemory     bool
-	UrlDecode          bool
-	UserMaxPartSize    int64
-	ObjectTags         types.Tagging
-	KMSKeyID           string
-	SSEAlgo            types.ServerSideEncryption
+	SrcManifest           string
+	SkipManifestHeader    bool
+	SrcBucket             string
+	SrcPrefix             string
+	SrcKey                string
+	DstBucket             string
+	DstPrefix             string
+	DstKey                string
+	Threads               int
+	DeleteSource          bool
+	Region                string
+	EndpointUrl           string
+	ExternalToc           string
+	tarFormat             tar.Format
+	storageClass          types.StorageClass
+	extractPrefix         string
+	ConcatInMemory        bool
+	UrlDecode             bool
+	UserMaxPartSize       int64
+	ObjectTags            types.Tagging
+	KMSKeyID              string
+	SSEAlgo               types.ServerSideEncryption
+	PreservePOSIXMetadata bool
 }
 
 func TagsToUrlEncodedString(tagging types.Tagging) string {


### PR DESCRIPTION
Implements Issue awslabs/amazon-s3-tar-tool#23

When creating tar archives, copy POSIX metadata from S3 headers into TAR headers.
When extracting tar archives, set S3 headers using POSIX metadata from TAR headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
