### PR TITLE
Allow different destination region

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,12 +19,13 @@ type Archiver interface {
 	List(context.Context, string, *S3TarS3Options, ...func(*S3TarS3Options)) (TOC, error)
 }
 
-func NewArchiveClient(client *s3.Client) Archiver {
-	return &ArchiveClient{client}
+func NewArchiveClient(client *s3.Client, dstClient *s3.Client) Archiver {
+	return &ArchiveClient{client, dstClient}
 }
 
 type ArchiveClient struct {
-	client *s3.Client
+	client    *s3.Client
+	dstClient *s3.Client
 }
 
 // Create an archive from existing files in Amazon S3.
@@ -34,7 +35,7 @@ func (a *ArchiveClient) Create(ctx context.Context, options *S3TarS3Options, opt
 	if err != nil {
 		return err
 	}
-	return ServerSideTar(ctx, a.client, opts)
+	return ServerSideTar(ctx, a.client, a.dstClient, opts)
 
 }
 
@@ -45,7 +46,7 @@ func (a *ArchiveClient) CreateFromList(ctx context.Context, objectList []*S3Obj,
 		return err
 	}
 
-	return createFromList(ctx, a.client, objectList, opts)
+	return createFromList(ctx, a.client, a.dstClient, objectList, opts)
 }
 
 func (a *ArchiveClient) checkArgs(options *S3TarS3Options, optFns []func(s3Options *S3TarS3Options)) (*S3TarS3Options, error) {

--- a/cmd/s3tar/main_test.go
+++ b/cmd/s3tar/main_test.go
@@ -33,19 +33,21 @@ func printHelp() {
 
 type mockArchiveManifest struct {
 	mockArchive
-	client *s3.Client
+	client    *s3.Client
+	dstClient *s3.Client
 }
 
-func newMockArchiveManifest(client *s3.Client) s3tar.Archiver {
-	return &mockArchiveManifest{client: client}
+func newMockArchiveManifest(client *s3.Client, dstClient *s3.Client) s3tar.Archiver {
+	return &mockArchiveManifest{client: client, dstClient: dstClient}
 }
 
 type mockArchive struct {
-	client *s3.Client
+	client    *s3.Client
+	dstClient *s3.Client
 }
 
-func newMockArchive(client *s3.Client) s3tar.Archiver {
-	return &mockArchive{client}
+func newMockArchive(client *s3.Client, dstClient *s3.Client) s3tar.Archiver {
+	return &mockArchive{client, dstClient}
 }
 func (a *mockArchive) Extract(ctx context.Context, opts *s3tar.S3TarS3Options, optFns ...func(options *s3tar.S3TarS3Options)) error {
 	return nil
@@ -125,7 +127,7 @@ func Test_cli(t *testing.T) {
 	}
 	tests := []struct {
 		name               string
-		archiveInitializer func(*s3.Client) s3tar.Archiver
+		archiveInitializer func(*s3.Client, *s3.Client) s3tar.Archiver
 		listObjFun         func(context.Context, *s3.Client, string, string, ...func(types.Object) bool) ([]*s3tar.S3Obj, int64, error)
 		listObjManifest    func(context.Context, *s3.Client, string, bool, bool) ([]*s3tar.S3Obj, int64, error)
 		args               args


### PR DESCRIPTION
To allow packing data from one region to an archive in different region, additional argument --dstRegion (and --dstEndpointUrl) are introduced and separate client is created if needed.

Change is backwards compatible, the client defaults to the same as the source one if neither dstRegion or dstEndpointUrl are specified.

In the code, I tried to disambiguate the source (without prefix) service/client from that is used for listing and getting object headers from the one used for putting object (copies) which can take the source object from different region easily.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
